### PR TITLE
Fixed ? case to ensure the last character of command is a `?` not just that it contains it

### DIFF
--- a/lab-1/server.py
+++ b/lab-1/server.py
@@ -33,7 +33,7 @@ def client_thread(connection):
             numbers = tokens[1].split('/')
             reply = str(int(numbers[0]) / int(numbers[1]))
         elif command[-1:] == "?":
-			#makes sure the command ends with a '?', not just contains one
+            #makes sure the command ends with a '?', not just contains one
             reply = '42'
         elif command == 'rev':
             reply = tokens[1][::-1]

--- a/lab-1/server.py
+++ b/lab-1/server.py
@@ -32,7 +32,8 @@ def client_thread(connection):
         elif command == 'div':
             numbers = tokens[1].split('/')
             reply = str(int(numbers[0]) / int(numbers[1]))
-        elif command.find('?') > 0:
+        elif command[-1:] == "?":
+			#makes sure the command ends with a '?', not just contains one
             reply = '42'
         elif command == 'rev':
             reply = tokens[1][::-1]


### PR DESCRIPTION
.find() returns the index that the substring is inside the string. The assignment says "If the server receives an unknown command that ends with a '?' - it must respond with "42". Using .find() it would return 42 even if you sent the command "hello?world", it's not ending with a ? but .find() will still be greater than 1. This fixes that to ensure that the last character of the command is ? 
